### PR TITLE
AB#625141 rebrand status page

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -5,7 +5,7 @@ on:
     branches: ['main']
   workflow_dispatch:
   schedule:
-    - cron: '0 */2 * * *'
+    - cron: '*/5 * * * *'
   issues:
     types: [opened, closed]
 

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -51,8 +51,7 @@ jobs:
         id: metrics
         env:
           SOURCES: |
-            GitHub->https://github.com
-            Facebook->https://facebook.com
+            CivicaScheduling->${{ secrets.SCHEDULING_URL }}
           GITHUB_TOKEN: ${{ github.token }}
           JOB_NAME: ${{ github.workflow }}
           ARTIFACT_NAME: ${{ env.ARTIFACT_NAME }}


### PR DESCRIPTION
This change sets the url for the health check as the secret variable which is the scheduling page url. The cron schedule has also been updated to match the schedule of the elb health checker in aws. 